### PR TITLE
Update README.md to fix Docker run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Clone this repo, then:
 
 ```bash
 docker build -t proxycore .
-docker run --rm -it -e PROXYCORE_HOSTNAME=encode.io PROXYCORE_ROOT_PATH=/httpcore -p 8000:8000 proxycore
+docker run --rm -it -e PROXYCORE_HOSTNAME=encode.io -e PROXYCORE_ROOT_PATH=/httpcore -p 8000:8000 proxycore
 ```
 
 This will proxy https://www.encode.io/httpcore (the HTTPCore documentation) from `localhost:8000`.


### PR DESCRIPTION
Fixed Docker run command as it was missing "-e" for the second env var.